### PR TITLE
Patch to support logging

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
     pkgload,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: mrc-ide/outpack@mrc-3734
+Remotes: mrc-ide/outpack

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     fs,
     jsonlite,
     orderly,
-    outpack (>= 0.2.4),
+    outpack (>= 0.2.6),
     withr,
     yaml
 Suggests:
@@ -27,4 +27,4 @@ Suggests:
     pkgload,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: mrc-ide/outpack
+Remotes: mrc-ide/outpack@mrc-3734

--- a/R/root.R
+++ b/R/root.R
@@ -35,7 +35,7 @@ orderly_root <- function(root, locate) {
 }
 
 
-orderly_init <- function(path) {
+orderly_init <- function(path, ...) {
   if (file.exists(path)) {
     if (!is_directory(path) || length(dir(path)) > 0) {
       stop("'path', if it already exists, must be an empty directory")
@@ -43,7 +43,7 @@ orderly_init <- function(path) {
   } else {
     fs::dir_create(path)
   }
-  outpack::outpack_init(path)
+  outpack::outpack_init(path, ...)
   file.create(file.path(path, "orderly_config.yml"))
   orderly_root(path, locate = FALSE)
 }

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -6,7 +6,7 @@ options(outpack.schema_validate =
 test_prepare_orderly_example <- function(examples, ...) {
   tmp <- tempfile()
   withr::defer_parent(unlink(tmp, recursive = TRUE))
-  orderly_init(tmp)
+  orderly_init(tmp, logging_console = FALSE)
 
   config <- character()
 

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -12,7 +12,7 @@ test_that("Configuration must exist", {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE))
   fs::dir_create(tmp)
-  outpack::outpack_init(tmp)
+  outpack::outpack_init(tmp, logging_console = FALSE)
   expect_error(orderly_config(tmp),
                "Orderly configuration does not exist: 'orderly_config.yml'")
   expect_error(orderly_root(tmp, FALSE),
@@ -25,7 +25,7 @@ test_that("Initialisation requires empty directory", {
   fs::dir_create(tmp)
   on.exit(unlink(tmp, recursive = TRUE))
   file.create(file.path(tmp, "file"))
-  expect_error(orderly_init(tmp),
+  expect_error(orderly_init(tmp, logging_console = FALSE),
                "'path', if it already exists, must be an empty directory")
 })
 
@@ -33,7 +33,7 @@ test_that("Initialisation requires empty directory", {
 test_that("Can initialise a new orderly root", {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE))
-  root <- orderly_init(tmp)
+  root <- orderly_init(tmp, logging_console = FALSE)
   expect_true(file.exists(tmp))
   expect_s3_class(root, "orderly_root")
   expect_s3_class(root$outpack, "outpack_root")
@@ -44,7 +44,7 @@ test_that("Can initialise a new orderly root", {
 test_that("Can validate global resources", {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE))
-  root <- orderly_init(tmp)
+  root <- orderly_init(tmp, logging_console = FALSE)
   writeLines("global_resources: global", file.path(tmp, "orderly_config.yml"))
   expect_error(orderly_config(tmp),
                "Global resource directory does not exist: 'global'")

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -9,7 +9,8 @@ test_that("can run simple task with explicit inputs and outputs", {
   ## All outputs as expected
   path_res <- file.path(path, "archive", "explicit", id)
   expect_true(is_directory(path_res))
-  expect_setequal(dir(path_res), c("orderly.R", "mygraph.png", "data.csv"))
+  expect_setequal(dir(path_res),
+                  c("orderly.R", "mygraph.png", "data.csv", "log.json"))
 
   ## Nothing left in drafts
   expect_true(is_directory(file.path(path, "draft", "explicit")))
@@ -45,7 +46,8 @@ test_that("can run simple task with implicit inputs and outputs", {
   ## All outputs as expected
   path_res <- file.path(path, "archive", "implicit", id)
   expect_true(is_directory(path_res))
-  expect_setequal(dir(path_res), c("orderly.R", "mygraph.png", "data.csv"))
+  expect_setequal(dir(path_res),
+                  c("orderly.R", "mygraph.png", "data.csv", "log.json"))
 
   ## Nothing left in drafts
   expect_true(is_directory(file.path(path, "draft", "implicit")))
@@ -97,7 +99,7 @@ test_that("cope with computed values in static functions", {
   id <- orderly_run("computed-resource", root = path, envir = env)
   expect_setequal(
     dir(file.path(path, "archive", "computed-resource", id)),
-    c("data.csv", "mygraph.png", "orderly.R"))
+    c("data.csv", "mygraph.png", "orderly.R", "log.json"))
 })
 
 
@@ -177,7 +179,7 @@ test_that("can run with global resources", {
   id <- orderly_run("global", root = path, envir = env)
   expect_setequal(
     dir(file.path(path, "archive", "global", id)),
-    c("global_data.csv", "mygraph.png", "orderly.R"))
+    c("global_data.csv", "mygraph.png", "orderly.R", "log.json"))
   root <- orderly_root(path, FALSE)
   meta <- root$outpack$metadata(id, full = TRUE)
   expect_length(meta$custom$orderly$global, 1)
@@ -243,7 +245,7 @@ test_that("global resources can be directories", {
 
   expect_setequal(
     dir(file.path(path, "archive", "global-dir", id)),
-    c("global_data", "output.rds", "orderly.R"))
+    c("global_data", "output.rds", "orderly.R", "log.json"))
   expect_setequal(
     dir(file.path(path, "archive", "global-dir", id, "global_data")),
     c("iris.csv", "mtcars.csv"))


### PR DESCRIPTION
This is pretty minimal and does not take real advantage of the logging, nor does it properly set up the orderly_init function which is still not exported; see vimc-7089

~Merge in tandem with https://github.com/mrc-ide/outpack/pull/49~

Now that https://github.com/mrc-ide/outpack/pull/49 is merged, no other orderly3 branches will pass until this is merged, and some tweaking to them will be needed