### PR TITLE
Expose logging interface to report running

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -14,6 +14,18 @@
 ##'   report script; by default we use the global environment, which
 ##'   may not always be what is wanted.
 ##'
+##' @param logging_console Optional logical, passed through to
+##'   [outpack::outpack_packet_start] to control printing logs to the
+##'   console, overriding any default configuration set at the root.
+##'
+##' @param logging_threshold Optional logging threshold, passed through to
+##'   [outpack::outpack_packet_start] to control the amount of detail
+##'   in logs printed during running, overriding any default
+##'   configuration set at the root. If given, must be one of `info`,
+##'   `debug` or `trace` (in increasing order of
+##'   verbosity). Practically this has no effect at present as we've
+##'   not added any fine-grained logging.
+##'
 ##' @param root The path to an orderly root directory, or `NULL`
 ##'   (the default) to search for one from the current working
 ##'   directory if `locate` is `TRUE`.
@@ -27,6 +39,7 @@
 ##'
 ##' @export
 orderly_run <- function(name, parameters = NULL, envir = NULL,
+                        logging_console = NULL, logging_threshold = NULL,
                         root = NULL, locate = TRUE) {
   root <- orderly_root(root, locate)
   src <- file.path(root$path, "src", name)
@@ -62,8 +75,9 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
   }
 
   p <- outpack::outpack_packet_start(path, name, parameters = parameters,
-                                     id = id, root = root$outpack,
-                                     local = TRUE)
+                                     id = id, logging_console = logging_console,
+                                     logging_threshold = logging_threshold,
+                                     root = root$outpack, local = TRUE)
   withCallingHandlers({
     outpack::outpack_packet_file_mark("orderly.R", "immutable", packet = p)
     p$orderly3 <- list(config = root$config, envir = envir, src = src,

--- a/man/orderly_run.Rd
+++ b/man/orderly_run.Rd
@@ -4,7 +4,15 @@
 \alias{orderly_run}
 \title{Run a report}
 \usage{
-orderly_run(name, parameters = NULL, envir = NULL, root = NULL, locate = TRUE)
+orderly_run(
+  name,
+  parameters = NULL,
+  envir = NULL,
+  logging_console = NULL,
+  logging_threshold = NULL,
+  root = NULL,
+  locate = TRUE
+)
 }
 \arguments{
 \item{name}{Name of the report to run}
@@ -16,6 +24,18 @@ must be a scalar character, numeric, integer or logical.}
 \item{envir}{The environment that will be used to evaluate the
 report script; by default we use the global environment, which
 may not always be what is wanted.}
+
+\item{logging_console}{Optional logical, passed through to
+\link[outpack:outpack_packet]{outpack::outpack_packet_start} to control printing logs to the
+console, overriding any default configuration set at the root.}
+
+\item{logging_threshold}{Optional logging threshold, passed through to
+\link[outpack:outpack_packet]{outpack::outpack_packet_start} to control the amount of detail
+in logs printed during running, overriding any default
+configuration set at the root. If given, must be one of \code{info},
+\code{debug} or \code{trace} (in increasing order of
+verbosity). Practically this has no effect at present as we've
+not added any fine-grained logging.}
 
 \item{root}{The path to an orderly root directory, or \code{NULL}
 (the default) to search for one from the current working

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -544,3 +544,14 @@ test_that("can pull resources programmatically, strictly", {
   expect_setequal(meta2$files$path,
                   c("b.csv", "data.rds", "orderly.R", "log.json"))
 })
+
+
+test_that("can enable logging at the packet level", {
+  path <- test_prepare_orderly_example("data")
+  res <- testthat::evaluate_promise(
+    orderly_run("data", root = path, logging_console = TRUE))
+  expect_match(res$messages,
+               "[ name       ]  data\n",
+               fixed = TRUE, all = FALSE)
+  expect_match(res$output, "orderly3::orderly_artefact")
+})


### PR DESCRIPTION
Missed this in #12, just passes args through