### PR TITLE
Cope better with failed scripts

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,4 +27,4 @@ Suggests:
     pkgload,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: mrc-ide/outpack@mrc-3134
+Remotes: mrc-ide/outpack

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,7 @@ Imports:
     fs,
     jsonlite,
     orderly,
-    outpack (>= 0.3.1),
+    outpack (>= 0.3.2),
     withr,
     yaml
 Suggests:
@@ -27,4 +27,4 @@ Suggests:
     pkgload,
     testthat (>= 3.0.0)
 Config/testthat/edition: 3
-Remotes: mrc-ide/outpack
+Remotes: mrc-ide/outpack@mrc-3134

--- a/R/metadata.R
+++ b/R/metadata.R
@@ -248,8 +248,8 @@ orderly_dependency <- function(name, query, use) {
   assert_named(use, unique = TRUE)
 
   ctx <- orderly_context()
-  id <- outpack::outpack_query(query, ctx$parameters, name = name,
-                               require_unpacked = TRUE, root = ctx$root)
+  id <- outpack::outpack_search(query, ctx$parameters, name = name,
+                                require_unpacked = TRUE, root = ctx$root)
   if (ctx$is_active) {
     outpack::outpack_packet_use_dependency(ctx$packet, id, use)
     ## See mrc-4203; we'll do this in outpack soon

--- a/R/run.R
+++ b/R/run.R
@@ -90,9 +90,9 @@ orderly_run <- function(name, parameters = NULL, envir = NULL,
     }
 
     result <- outpack::outpack_packet_run(p, "orderly.R", envir)
-    orderly_packet_cleanup(p)
+    orderly_packet_cleanup_success(p)
   }, error = function(e) {
-    outpack::outpack_packet_end(p, insert = FALSE)
+    orderly_packet_cleanup_failure(p)
   })
   id
 }

--- a/R/util.R
+++ b/R/util.R
@@ -136,3 +136,8 @@ copy_files <- function(src, dst, files, overwrite = FALSE) {
                 file.path(dst, files),
                 overwrite = overwrite)
 }
+
+
+ignore_errors <- function(expr) {
+  tryCatch(expr, function(e) NULL)
+}

--- a/R/util.R
+++ b/R/util.R
@@ -139,5 +139,5 @@ copy_files <- function(src, dst, files, overwrite = FALSE) {
 
 
 ignore_errors <- function(expr) {
-  tryCatch(expr, function(e) NULL)
+  tryCatch(expr, error = function(e) NULL)
 }

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -610,3 +610,25 @@ test_that("can enable logging at the packet level", {
                fixed = TRUE, all = FALSE)
   expect_match(res$output, "orderly3::orderly_artefact")
 })
+
+
+
+test_that("cope with failed run", {
+  path <- test_prepare_orderly_example("implicit")
+  prepend_lines(file.path(path, "src", "implicit", "orderly.R"),
+                'd <- read.csv("something.csv")')
+  err <- expect_error(
+    orderly_run("implicit", root = path),
+    "cannot open the connection",
+    class = "outpack_packet_run_error")
+  expect_length(dir(file.path(path, "archive", "implicit")), 0)
+  id <- dir(file.path(path, "draft", "implicit"))
+  expect_length(id, 1)
+  expect_setequal(
+    dir(file.path(path, "draft", "implicit", id)),
+    c("data.csv", "log.json", "orderly.R", "outpack.json"))
+
+  d <- outpack::outpack_metadata_read(
+    file.path(path, "draft", "implicit", id, "outpack.json"))
+  expect_equal(d$id, id)
+})

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -228,7 +228,7 @@ test_that("can't use global resources if not enabled", {
     "'global_resources' is not supported; please edit orderly_config.yml")
   expect_error(
     withr::with_dir(path_src, sys.source("orderly.R", env)),
-    err$message, fixed = TRUE)
+    "'global_resources' is not supported; please edit orderly_config.yml")
 })
 
 


### PR DESCRIPTION
This one, in contrast with the outpack support (https://github.com/mrc-ide/outpack/pull/56), is fairly straightforward:

* general refactoring of the main run function to expose two clear cleanup paths - the happy one and the unhappy one
* happy path has no logic changes
* unhappy path uses new outpack function to dump out metadata (see that PR for details) and will surface errors to the user as they happen (hard to test automatically because of the way the handerlers work)