### PR TITLE
mrc-4365: check minimum version

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: orderly3
 Title: Orderly Next Next Generation
-Version: 0.1.1
+Version: 1.99.0
 Authors@R: c(person("Rich", "FitzJohn", role = c("aut", "cre"),
                     email = "rich.fitzjohn@gmail.com"),
              person("Robert", "Ashton", role = "aut"),

--- a/R/config.R
+++ b/R/config.R
@@ -16,10 +16,11 @@ orderly_config_yml_read <- function(path) {
   raw <- resolve_env(raw, orderly_envir_read(path), "orderly_config.yml")
 
   check <- list(
+    minimum_orderly_version = orderly_config_validate_minimum_orderly_version,
     plugins = orderly_config_validate_plugins,
     global_resources = orderly_config_validate_global_resources)
 
-  required <- character()
+  required <- "minimum_orderly_version"
   optional <- setdiff(names(check), required)
   check_fields(raw, filename, required, optional)
 
@@ -32,6 +33,21 @@ orderly_config_yml_read <- function(path) {
   }
 
   dat
+}
+
+
+orderly_config_validate_minimum_orderly_version <- function(value, filename) {
+  assert_scalar_character(value)
+  version <- numeric_version(value)
+  if (version < numeric_version("1.99.0")) {
+    stop("Migrate from version 1, see docs that we need to write still...")
+  }
+  if (version > current_orderly_version()) {
+    stop(sprintf(
+      "orderly version '%s' is required, but only '%s' installed",
+      version, current_orderly_version()))
+  }
+  version
 }
 
 

--- a/R/root.R
+++ b/R/root.R
@@ -44,6 +44,7 @@ orderly_init <- function(path, ...) {
     fs::dir_create(path)
   }
   outpack::outpack_init(path, ...)
-  file.create(file.path(path, "orderly_config.yml"))
+  writeLines('minimum_orderly_version: "1.99.0"',
+             file.path(path, "orderly_config.yml"))
   orderly_root(path, locate = FALSE)
 }

--- a/R/root.R
+++ b/R/root.R
@@ -44,7 +44,11 @@ orderly_init <- function(path, ...) {
     fs::dir_create(path)
   }
   outpack::outpack_init(path, ...)
-  writeLines('minimum_orderly_version: "1.99.0"',
-             file.path(path, "orderly_config.yml"))
+  writeLines(empty_config_contents(), file.path(path, "orderly_config.yml"))
   orderly_root(path, locate = FALSE)
+}
+
+
+empty_config_contents <- function() {
+  'minimum_orderly_version: "1.99.0"'
 }

--- a/R/util.R
+++ b/R/util.R
@@ -146,3 +146,8 @@ copy_files <- function(src, dst, files, overwrite = FALSE) {
 ignore_errors <- function(expr) {
   tryCatch(expr, error = function(e) NULL)
 }
+
+
+current_orderly_version <- function() {
+  utils::packageVersion("orderly3")
+}

--- a/tests/testthat/helper-orderly.R
+++ b/tests/testthat/helper-orderly.R
@@ -7,8 +7,7 @@ test_prepare_orderly_example <- function(examples, ...) {
   tmp <- tempfile()
   withr::defer_parent(unlink(tmp, recursive = TRUE))
   orderly_init(tmp, logging_console = FALSE)
-
-  config <- character()
+  config <- readLines(file.path(tmp, "orderly_config.yml"))
 
   if (any(c("global", "global-dir") %in% examples)) {
     config <- c(config,

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -44,3 +44,19 @@ test_that("can interpolate values into an orderly configuration", {
   writeLines("PATH_GLOBAL: global", file.path(path, "orderly_envir.yml"))
   expect_equal(orderly_root(path, FALSE)$config$global_resources, "global")
 })
+
+
+test_that("can validate minimum required version", {
+  expect_error(
+    orderly_config_validate_minimum_orderly_version("1.4.5", "orderly.yml"),
+    "Migrate from version 1, see docs that we need to write still...",
+    fixed = TRUE)
+  expect_error(
+    orderly_config_validate_minimum_orderly_version("99.0.0", "orderly.yml"),
+    sprintf("orderly version '99.0.0' is required, but only '%s' installed",
+            current_orderly_version()),
+    fixed = TRUE)
+  expect_equal(
+    orderly_config_validate_minimum_orderly_version("1.99.0", "orderly.yml"),
+    numeric_version("1.99.0"))
+})

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -31,7 +31,8 @@ test_that("can interpolate values into an orderly configuration", {
   path <- test_prepare_orderly_example("global")
   expect_equal(orderly_root(path, FALSE)$config$global_resources, "global")
 
-  writeLines("global_resources: $PATH_GLOBAL",
+  writeLines(c(empty_config_contents(),
+               "global_resources: $PATH_GLOBAL"),
              file.path(path, "orderly_config.yml"))
   expect_error(
     orderly_root(path, FALSE),

--- a/tests/testthat/test-plugin.R
+++ b/tests/testthat/test-plugin.R
@@ -90,7 +90,7 @@ test_that("don't load package if plugin already loaded", {
 
 test_that("error if packet uses non-configured plugin", {
   path <- test_prepare_orderly_example("plugin")
-  file.create(file.path(path, "orderly_config.yml"))
+  writeLines(empty_config_contents(), file.path(path, "orderly_config.yml"))
 
   env <- new.env()
   expect_error(

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -2,7 +2,8 @@ test_that("Configuration must be empty", {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE))
   fs::dir_create(tmp)
-  writeLines("a: 1", file.path(tmp, "orderly_config.yml"))
+  writeLines(c(empty_config_contents(), "a: 1"),
+             file.path(tmp, "orderly_config.yml"))
   expect_error(orderly_config(tmp),
                "Unknown fields in .+: a")
 })
@@ -46,7 +47,9 @@ test_that("Can validate global resources", {
   tmp <- tempfile()
   on.exit(unlink(tmp, recursive = TRUE))
   root <- orderly_init(tmp, logging_console = FALSE)
-  writeLines("global_resources: global", file.path(tmp, "orderly_config.yml"))
+  writeLines(c(empty_config_contents(),
+               "global_resources: global"),
+             file.path(tmp, "orderly_config.yml"))
   expect_error(orderly_config(tmp),
                "Global resource directory does not exist: 'global'")
   dir.create(file.path(tmp, "global"))

--- a/tests/testthat/test-root.R
+++ b/tests/testthat/test-root.R
@@ -37,7 +37,8 @@ test_that("Can initialise a new orderly root", {
   expect_true(file.exists(tmp))
   expect_s3_class(root, "orderly_root")
   expect_s3_class(root$outpack, "outpack_root")
-  expect_equal(root$config, list())
+  expect_equal(root$config,
+               list(minimum_orderly_version = numeric_version("1.99.0")))
 })
 
 

--- a/tests/testthat/test-run.R
+++ b/tests/testthat/test-run.R
@@ -237,7 +237,7 @@ test_that("can validate global resource arguments", {
 
 test_that("can't use global resources if not enabled", {
   path <- test_prepare_orderly_example("global")
-  file.create(file.path(path, "orderly_config.yml")) # truncates file
+  writeLines(empty_config_contents(), file.path(path, "orderly_config.yml"))
   env <- new.env()
   path_src <- file.path(path, "src", "global")
   err <- expect_error(


### PR DESCRIPTION
I've yanked the version number way up here to a value that is below 2.0.0 but above the greatest version we'll give orderly. The logic for testing here is the same as for orderly, except that throw a different message if the version required is in the 1.x series